### PR TITLE
🐛 Implement rebuilding documents with the directive on fragments changes granularly

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -59,7 +59,8 @@ per-file-ignores =
   # tool-related comments;
   # WPS412 logic of an extension is in __init__.py file;
   # FIXME: WPS201 too many imports
-  src/sphinxcontrib/towncrier/__init__.py: E800, WPS201, WPS412
+  # FIXME: WPS402 too many `noqa`s
+  src/sphinxcontrib/towncrier/__init__.py: E800, WPS201, WPS402, WPS412
 
 # wemake-python-styleguide
 show-source = true
@@ -72,3 +73,10 @@ pytest-parametrize-names-type = tuple
 # PT007:
 pytest-parametrize-values-type = tuple
 pytest-parametrize-values-row-type = tuple
+
+# flake8-rst-docstrings
+rst-roles =
+    # Built-in Sphinx roles:
+    py:class,
+    py:meth,
+    std:event,

--- a/.flake8
+++ b/.flake8
@@ -58,7 +58,8 @@ per-file-ignores =
   # E800 reports a lot of false-positives for legit
   # tool-related comments;
   # WPS412 logic of an extension is in __init__.py file;
-  src/sphinxcontrib/towncrier/__init__.py: E800, WPS412
+  # FIXME: WPS201 too many imports
+  src/sphinxcontrib/towncrier/__init__.py: E800, WPS201, WPS412
 
 # wemake-python-styleguide
 show-source = true

--- a/mypy.ini
+++ b/mypy.ini
@@ -16,3 +16,6 @@ strict_optional = True
 
 warn_redundant_casts = True
 warn_unused_ignores = True
+
+[mypy-towncrier.*]
+ignore_missing_imports = True

--- a/src/sphinxcontrib/towncrier/__init__.py
+++ b/src/sphinxcontrib/towncrier/__init__.py
@@ -66,7 +66,7 @@ def _get_changelog_draft_entries(
     return towncrier_output
 
 
-def iter_towncrier_files(fragments_dir: Path) -> Iterable:
+def iter_towncrier_files(fragments_dir: Path) -> Iterable[Path]:
     for path in Path(fragments_dir).iterdir():
         if path.is_file() and path.suffix == "rst":
             yield path

--- a/src/sphinxcontrib/towncrier/__init__.py
+++ b/src/sphinxcontrib/towncrier/__init__.py
@@ -142,7 +142,7 @@ class TowncrierDraftEntriesDirective(SphinxDirective):
                 'only one argument permitted.',
             )
 
-        config = self.state.document.settings.env.config  # noqa: WPS219
+        config = self.env.config
         autoversion_mode = config.towncrier_draft_autoversion_mode
         include_empty = config.towncrier_draft_include_empty
 

--- a/src/sphinxcontrib/towncrier/__init__.py
+++ b/src/sphinxcontrib/towncrier/__init__.py
@@ -67,6 +67,7 @@ def _get_changelog_draft_entries(
 
 
 def iter_towncrier_files(fragments_dir: Path) -> Iterable[Path]:
+    """Emit RST-formatted Towncrier changelog fragment paths."""
     for path in Path(fragments_dir).iterdir():
         if path.is_file() and path.suffix == "rst":
             yield path

--- a/src/sphinxcontrib/towncrier/__init__.py
+++ b/src/sphinxcontrib/towncrier/__init__.py
@@ -3,12 +3,15 @@
 
 import subprocess  # noqa: S404
 import sys
+from contextlib import suppress as suppress_exceptions
 from functools import lru_cache
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 from sphinx.application import Sphinx
 from sphinx.config import Config as SphinxConfig
+from sphinx.environment import BuildEnvironment
+from sphinx.environment.collectors import EnvironmentCollector
 from sphinx.util.docutils import SphinxDirective
 from sphinx.util.nodes import nested_parse_with_titles, nodes
 
@@ -166,24 +169,6 @@ class TowncrierDraftEntriesDirective(SphinxDirective):
 
     def run(self) -> List[nodes.Node]:  # noqa: WPS210
         """Generate a node tree in place of the directive."""
-        # NOTE: Keep `note_reread()` the first thing in the `run()` method.
-        # NOTE: This allows signalling sphinx to invalidate the doctree
-        # NOTE: cache of the document using this directive.
-        # NOTE: This could be more granular but needs more effort to teach
-        # NOTE: sphinx to depend on the appearance of the new files that
-        # NOTE: Towncrier understands. To implement this, one would need to
-        # NOTE: first persist on the mapping of the documents what use this
-        # NOTE: directive on the BuildEnvironment instance. And then, it's
-        # NOTE: needed to implement an EnvironmentCollector subcalss that
-        # NOTE: would merge different envs from parallel runs into one.
-        # NOTE: Finally, make use of env-get-outdated to call
-        # NOTE: BuildEnvironment.note_dependency() or better just return
-        # NOTE: those docnames recorded earlier.
-        # Refs:
-        # * https://github.com/sphinx-contrib/sphinxcontrib-towncrier/issues/1
-        # * https://github.com/sphinx-doc/sphinx/issues/8040
-        self.env.note_reread()  # rebuild the current RST doc unconditionally
-
         target_version = self.content[:1][0] if self.content[:1] else None
         if self.content[1:]:  # inner content present
             raise self.error(
@@ -204,6 +189,28 @@ class TowncrierDraftEntriesDirective(SphinxDirective):
             self.env.note_dependency(str(path))
 
         try:
+            self.env.towncrier_fragment_paths |= (  # type: ignore
+                towncrier_fragment_paths
+            )
+        except AttributeError:
+            # If the attribute hasn't existed, initialize it instead of
+            # updating
+            self.env.towncrier_fragment_paths = (  # type: ignore
+                towncrier_fragment_paths
+            )
+
+        try:
+            self.env.towncrier_fragment_docs |= {  # type: ignore
+                self.env.docname,
+            }
+        except AttributeError:
+            # If the attribute hasn't existed, initialize it instead of
+            # updating
+            self.env.towncrier_fragment_docs = {  # type: ignore
+                self.env.docname,
+            }
+
+        try:
             draft_changes = _get_changelog_draft_entries(
                 target_version or
                 _get_draft_version_fallback(autoversion_mode, config),
@@ -217,6 +224,122 @@ class TowncrierDraftEntriesDirective(SphinxDirective):
             return []
 
         return _nodes_from_rst(state=self.state, rst_source=draft_changes)
+
+
+class TowncrierDraftEntriesEnvironmentCollector(EnvironmentCollector):
+    r"""Environment collector for ``TowncrierDraftEntriesDirective``.
+
+    When :py:class:`~TowncrierDraftEntriesDirective` is used in a
+    document, it depends on some dynamically generated change fragments.
+    After the first render, the doctree nodes are put in cache and are
+    reused from there. There's a way to make Sphinx aware of the
+    directive dependencies by calling :py:meth:`~BuildEnvironment.\
+    note_dependency` but this will only work for fragments that have
+    existed at the time of that first directive invocation.
+
+    In order to track newly appearing change fragment dependencies,
+    we need to do so at the time of Sphinx identifying what documents
+    require rebuilding. There's :std:event:`env-get-outdated` that
+    allows to extend this list of planned rebuilds and we could use it
+    by assigning a document-to-fragments map from within the directive
+    and reading it in the event handler later (since env contents are
+    preserved in cache). But this approach does not take into account
+    cleanups and parallel runs of Sphinx. In order to make it truly
+    parallelism-compatible, we need to define how to merge our custom
+    cache attribute collected within multiple Sphinx subprocesses into
+    one object and that's where :py:class:`~EnvironmentCollector` comes
+    into play.
+
+    Refs:
+    * https://github.com/sphinx-doc/sphinx/issues/8040#issuecomment-671587308
+    * https://github.com/sphinx-contrib/sphinxcontrib-towncrier/issues/1
+    """
+
+    def clear_doc(
+            self,
+            app: Sphinx,
+            env: BuildEnvironment,
+            docname: str,
+    ) -> None:
+        """Clean up env metadata related to the removed document.
+
+        This is a handler for :std:event:`env-purge-doc`.
+        """
+        with suppress_exceptions(AttributeError, KeyError):
+            env.towncrier_fragment_docs.remove(docname)  # type: ignore
+
+    def merge_other(
+            self,
+            app: Sphinx,
+            env: BuildEnvironment,
+            docnames: Set[str],
+            other: BuildEnvironment,
+    ) -> None:
+        """Merge doc-to-fragments from another proc into this env.
+
+        This is a handler for :std:event:`env-merge-info`.
+        """
+        try:
+            other_fragment_docs: Set[str] = (
+                other.towncrier_fragment_docs  # type: ignore
+            )
+        except AttributeError:
+            # If the other process env doesn't have documents using
+            # `TowncrierDraftEntriesDirective`, there's nothing to merge
+            return
+
+        if not hasattr(env, 'towncrier_fragment_docs'):  # noqa: WPS421
+            # If the other process env doesn't have documents using
+            # `TowncrierDraftEntriesDirective`, initialize the structure
+            # at least
+            env.towncrier_fragment_docs = set()  # type: ignore
+
+        if not hasattr(env, 'towncrier_fragment_paths'):  # noqa: WPS421
+            env.towncrier_fragment_paths = set()  # type: ignore
+
+        # Since Sphinx does not pull the same document into multiple
+        # processes, we don't care about the same dict key appearing
+        # in different envs with different sets of the deps
+        env.towncrier_fragment_docs.update(  # type: ignore
+            other_fragment_docs,
+        )
+        env.towncrier_fragment_paths.update(  # type: ignore
+            other.towncrier_fragment_paths,  # type: ignore
+        )
+
+    def process_doc(self, app: Sphinx, doctree: nodes.document) -> None:
+        """React to :std:event:`doctree-read` with no-op."""
+
+    # pylint: disable=too-many-arguments
+    def get_outdated_docs(  # noqa: WPS211
+            self,
+            app: Sphinx,
+            env: BuildEnvironment,
+            added: Set[str],
+            changed: Set[str],
+            removed: Set[str],
+    ) -> List[str]:
+        """Mark docs with changed fragment deps for rebuild.
+
+        This is a handler for :std:event:`env-get-outdated`.
+        """
+        towncrier_fragment_paths = _lookup_towncrier_fragments(
+            working_dir=env.config.towncrier_draft_working_directory,
+            config_path=env.config.towncrier_draft_config_path,
+        )
+
+        fragments_changed = False
+        with suppress_exceptions(AttributeError):
+            fragments_changed = bool(
+                towncrier_fragment_paths
+                ^ env.towncrier_fragment_paths,  # type: ignore
+            )
+
+        return (
+            list(env.towncrier_fragment_docs - changed)  # type: ignore
+            if fragments_changed
+            else []
+        )
 
 
 def setup(app: Sphinx) -> Dict[str, Union[bool, str]]:
@@ -246,6 +369,10 @@ def setup(app: Sphinx) -> Dict[str, Union[bool, str]]:
         'towncrier-draft-entries',
         TowncrierDraftEntriesDirective,
     )
+
+    # Register an environment collector to merge data gathered by the
+    # directive in parallel builds
+    app.add_env_collector(TowncrierDraftEntriesEnvironmentCollector)
 
     return {
         'parallel_read_safe': True,


### PR DESCRIPTION
Closes #1 

This is very very early stage code.
I'm kinda assured that we'll need to deal with absolute vs relative path.

The current state of the repo doesn't easily allow to test, even manually, that something works. So this is the first step exploring this issue, but It's absolutely not ready for merging. Ooooor you can merge and fix later, anyway, the lib is not usable as-is, so it's not very different from being broken :D

Good luck for setting up all the boilerplate !