### PR TITLE
Replace old repo links with new ones

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,10 +3,10 @@ universal = 1
 
 [metadata]
 name = sphinxcontrib-towncrier
-url = https://github.com/sphinx-contrib/towncrier
+url = https://github.com/sphinx-contrib/sphinxcontrib-towncrier
 project_urls =
-    GitHub: repo = https://github.com/sphinx-contrib/towncrier
-    GitHub: issues = https://github.com/sphinx-contrib/towncrier/issues
+    GitHub: repo = https://github.com/sphinx-contrib/sphinxcontrib-towncrier
+    GitHub: issues = https://github.com/sphinx-contrib/sphinxcontrib-towncrier/issues
 description = An RST directive for injecting a Towncrier-generated changelog draft containing fragments for the unreleased (next) project version
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
Links were replaced to new ones while dist name already was `sphinxcontrib-towncrier` in `setup.cfg` so it's left unchanged.

Close #11