### PR TITLE
Add a tox config with `build-dists` env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,18 @@
+[testenv:build-dists]
+description =
+    Build dists and put them into the dists/ folder
+basepython = python3
+isolated_build = true
+# `usedevelop = true` overrides `skip_install` instruction, it's unwanted
+usedevelop = false
+skip_install = true
+deps =
+    pep517 >= 0.8.2
+commands =
+    {envpython} -c 'import shutil; \
+      shutil.rmtree("{toxinidir}/dist/")'
+    {envpython} -m pep517.build \
+      --source \
+      --binary \
+      --out-dir {toxinidir}/dist/ \
+      {toxinidir}


### PR DESCRIPTION
Now it's possible to produce dist under `dist/` folder with `tox -e build-dist`.
Local smoke tests works fine.

Close #19 