### PR TITLE
Fix build-dists command flow to ignore `No such file or directory` error

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     pep517 >= 0.8.2
 commands =
     {envpython} -c 'import shutil; \
-      shutil.rmtree("{toxinidir}/dist/")'
+      shutil.rmtree("{toxinidir}/dist/", ignore_errors=True)'
     {envpython} -m pep517.build \
       --source \
       --binary \


### PR DESCRIPTION
This will fix [failed](https://github.com/slsh1o/towncrier/runs/990026822?check_suite_focus=true#step:11:18) actions in `toxenvs:build-dists` .