### PR TITLE
Improve pylint config with project-specific settings

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -529,7 +529,10 @@ allow-wildcard-with-all=no
 analyse-fallback-blocks = yes
 
 # Deprecated modules which should not be used, separated by a comma.
-deprecated-modules=optparse,tkinter.tix
+deprecated-modules =
+  optparse,
+  tkinter.tix,
+  unittest,
 
 # Create a graph of external dependencies in the given file (report RP0402 must
 # not be disabled).
@@ -551,7 +554,8 @@ known-standard-library=
 known-third-party=enchant
 
 # Couples of modules and preferred modules, separated by a comma.
-preferred-modules=
+preferred-modules =
+  unittest:pytest,
 
 
 [DESIGN]

--- a/.pylintrc
+++ b/.pylintrc
@@ -22,7 +22,7 @@ ignore-patterns=
 
 # Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
 # number of processors available to use.
-jobs=1
+jobs = 0
 
 # Control the amount of potential inferred values when inferring a single
 # object. This can help the performance when dealing with large functions or

--- a/.pylintrc
+++ b/.pylintrc
@@ -526,7 +526,7 @@ allow-wildcard-with-all=no
 # Analyse import fallback blocks. This can be used to support both Python 2 and
 # 3 compatible code, which means that the block might have code that exists
 # only in one or another interpreter, leading to false positives when analysed.
-analyse-fallback-blocks=no
+analyse-fallback-blocks = yes
 
 # Deprecated modules which should not be used, separated by a comma.
 deprecated-modules=optparse,tkinter.tix

--- a/.pylintrc
+++ b/.pylintrc
@@ -408,9 +408,9 @@ function-naming-style=snake_case
 good-names=i,
            j,
            k,
-           ex,
-           Run,
-           _
+           exc,
+           logger,
+           _,
 
 # Good variable names regexes, separated by a comma. If names match any regex,
 # they will always be accepted

--- a/.pylintrc
+++ b/.pylintrc
@@ -417,7 +417,7 @@ good-names=i,
 good-names-rgxs=
 
 # Include a hint for the correct naming format with invalid-name.
-include-naming-hint=no
+include-naming-hint = yes
 
 # Naming style matching correct inline iteration names.
 inlinevar-naming-style=any


### PR DESCRIPTION
This change:
* makes pylint use parallelism for faster execution
* adjusts the good var names list
* enables name hints
* allows taking import fallbacks into account
* helps maintain the usage of pytest while avoiding stdlib unittest