### PR TITLE
Change ubuntu-latest to 18.04 in GHA

### DIFF
--- a/.github/workflows/tox-tests.yaml
+++ b/.github/workflows/tox-tests.yaml
@@ -22,7 +22,7 @@ jobs:
         - 3.7
         - 3.6
         os:
-        - ubuntu-latest
+        - ubuntu-18.04
         - ubuntu-20.04
         - macos-latest
         - macos-11.0


### PR DESCRIPTION
Because of near-future [changes](https://github.blog/changelog/2020-10-29-github-actions-ubuntu-latest-workflows-will-use-ubuntu-20-04/) to the `ubuntu-latest` version on GHA. The current `ubuntu-latest` version was changed explicitly to `18-04`.