### PR TITLE
Fix pre-commit py_hash_key in GHA

### DIFF
--- a/.github/workflows/tox-linters.yaml
+++ b/.github/workflows/tox-linters.yaml
@@ -54,7 +54,7 @@ jobs:
           hashFiles('pyproject.toml') }}-${{
           hashFiles('.pre-commit-config.yaml') }}
         restore-keys: |
-          ${{ runner.os }}-pip-${{steps.calc_cache_key_py.outputs.py_hash_key }}-
+          ${{ runner.os }}-pip-${{ steps.calc_cache_key_py.outputs.py_hash_key }}-
           ${{ runner.os }}-pip-
           ${{ runner.os }}-
     - name: Set up pre-commit cache
@@ -63,7 +63,7 @@ jobs:
         path: ~/.cache/pre-commit
         key: >-
           ${{ runner.os }}-pre-commit-${{
-          env.PY_SHA256 }}-${{
+          steps.calc_cache_key_py.outputs.py_hash_key }}-${{
           hashFiles('setup.cfg') }}-${{
           hashFiles('tox.ini') }}-${{
           hashFiles('pyproject.toml') }}-${{


### PR DESCRIPTION
Switch missed `env.PY_SHA256` to the hash calculated by another step.