### PR TITLE
🐛 Fix getting ref_type from github.event @ GHA

### DIFF
--- a/.github/workflows/tox-tests.yaml
+++ b/.github/workflows/tox-tests.yaml
@@ -12,7 +12,7 @@ jobs:
   tests:
     if: >-  # https://twitter.com/webKnjaZ/status/1308803017001652225
       github.event_name != 'create' ||
-      github.ref_type == 'tag'
+      github.event.ref_type == 'tag'
     name: >-
       ${{ matrix.python-version }}
       /


### PR DESCRIPTION
This change essentially corrects a typo in the conditional that was meant to filter
out branch creation workflows but keep the tag creations running.