### PR TITLE
Reduce the number of duplicate GHA workflows

### DIFF
--- a/.github/workflows/tox-tests.yaml
+++ b/.github/workflows/tox-tests.yaml
@@ -3,7 +3,15 @@ name: 👷tests
 
 on:
   create:
-  push:
+  push:  # publishes to TestPyPI pushes to the main branch
+    branches:  # any branch but not tag
+    - >-
+      **
+    - >-  # NOTE: "branches-ignore" cannot be used with "branches"
+      !dependabot/**
+    tags-ignore:
+    - >-
+      **
   pull_request:
   schedule:
   - cron: 1 0 * * *  # Run daily at 0:01 UTC


### PR DESCRIPTION
This change drops "tag push" runs and direct pushes by dependabot.