### PR TITLE
Support towncrier >= 21.9.0rc1

### DIFF
--- a/src/sphinxcontrib/towncrier/__init__.py
+++ b/src/sphinxcontrib/towncrier/__init__.py
@@ -37,6 +37,7 @@ PROJECT_ROOT_DIR = Path(__file__).parents[3].resolve()
 TOWNCRIER_DRAFT_CMD = (
     sys.executable, '-m',  # invoke via runpy under the same interpreter
     'towncrier',
+    'build',
     '--draft',  # write to stdout, don't change anything on disk
 )
 


### PR DESCRIPTION
Version 21.9.0rc1 of towncrier introduced ``--version`` for the tool,
which means that, if you want to pass ``--version`` when building the
changelog, you **must** pass the ``build`` command and not rely on the
default command being ``build``.