### PR TITLE
Escape RST substitution only when needed

### DIFF
--- a/src/sphinxcontrib/towncrier/__init__.py
+++ b/src/sphinxcontrib/towncrier/__init__.py
@@ -30,6 +30,9 @@ except ImportError:
 from docutils import statemachine  # pylint: disable=wrong-import-order
 
 from ._compat import shlex_join  # noqa: WPS436
+from ._data_transformers import (  # noqa: WPS436
+    escape_project_version_rst_substitution,
+)
 from ._towncrier import get_towncrier_config  # noqa: WPS436
 from ._version import __version__  # noqa: WPS436
 
@@ -56,16 +59,8 @@ def _get_changelog_draft_entries(
     """Retrieve the unreleased changelog entries from Towncrier."""
     extra_cli_args: Tuple[str, ...] = (
         '--version',
-        rf'\ {target_version}',  # version value to be used in the RST title
-        # NOTE: The escaped space sequence (`\ `) is necessary to address
-        # NOTE: a corner case when the towncrier config has something like
-        # NOTE: `v{version}` in the title format **and** the directive target
-        # NOTE: argument starts with a substitution like `|release|`. And so
-        # NOTE: when combined, they'd produce `v|release|` causing RST to not
-        # NOTE: substitute the `|release|` part. But adding an escaped space
-        # NOTE: solves this: that escaped space renders as an empty string and
-        # NOTE: the substitution gets processed properly so the result would
-        # NOTE: be something like `v1.0` as expected.
+        # A version to be used in the RST title:
+        escape_project_version_rst_substitution(target_version),
     )
     if config_path is not None:
         # This isn't actually supported by a released version of Towncrier yet:

--- a/src/sphinxcontrib/towncrier/_data_transformers.py
+++ b/src/sphinxcontrib/towncrier/_data_transformers.py
@@ -1,0 +1,17 @@
+"""Data transformation helpers."""
+
+
+def escape_project_version_rst_substitution(version: str) -> str:
+    """Prepend an escaped whitespace before RST substitution."""
+    if not version.startswith('|') or version.count('|') <= 1:
+        return version
+
+    # A corner case exists when the towncrier config has something like
+    # `v{version}` in the title format **and** the directive target
+    # argument starts with a substitution like `|release|`. And so
+    # when combined, they produce a v|release|` causing RST to not
+    # substitute the `|release|` part. But adding an escaped space
+    # solves this: that escaped space renders as an empty string and
+    # the substitution gets processed properly so the result would
+    # be something like `v1.0` as expected.
+    return rf'\ {version}'

--- a/tests/_data_transformers_test.py
+++ b/tests/_data_transformers_test.py
@@ -1,0 +1,30 @@
+"""Data transformation tests."""
+import pytest
+
+from sphinxcontrib.towncrier._data_transformers import (
+    escape_project_version_rst_substitution,
+)
+
+
+@pytest.mark.parametrize(
+    ('test_input', 'escaped_input'),
+    (
+        (r'\ |release|', r'\ |release|'),
+        ('|release|', r'\ |release|'),
+        ('|release', '|release'),
+        ('v|release|', 'v|release|'),
+    ),
+    ids=(
+        'substitution already escaped',
+        'correct substitution at the beginning',
+        'unclosed substitution at the beginning',
+        'correct substitution in the middle',
+    ),
+)
+def test_escape_version(test_input, escaped_input):
+    """Test that the version is escaped before RST substitutions.
+
+    RST substitution as the first item should be escaped. Otherwise,
+    the input is expected to remain unchanged.
+    """
+    assert escape_project_version_rst_substitution(test_input) == escaped_input

--- a/tests/units_test.py
+++ b/tests/units_test.py
@@ -85,7 +85,7 @@ def test_towncrier_draft_generation_failure_msg(
     expected_error_message = (
         '^'  # noqa: WPS221
         'Command exited unexpectedly.\n\n'
-        rf"Command: {escaped_failing_cmd} --version '\\ {version_string}'\n"
+        rf"Command: {escaped_failing_cmd} --version '{version_string}'\n"
         f'Return code: {expected_return_code}\n\n'
         'Standard output:\n'
         f'{stdout_msg}\n\n'


### PR DESCRIPTION
I was running into some issues with a random `\` being added at the beginning of my draft changelog. I am not using the default RST parser, instead I am making use of a Markdown one, which made the character visible instead of rendering as an empty character.

Hopefully adding it only when needed is a valid solution to this issue! Let me know if there is anything I am missing from the PR.

Would also like to kindly ask for a release when this PR is merged, as the project seems stable enough and doesnt receive any consistent releases :)