### PR TITLE
Adjust the config loader import to support `towncrier >= 22.8.0rc1`

### DIFF
--- a/.github/workflows/tox-tests.yaml
+++ b/.github/workflows/tox-tests.yaml
@@ -75,6 +75,8 @@ jobs:
         exclude:
         - os: ubuntu-22.04
           python-version: 3.6  # EOL, only provided for older OSs
+        - python-version: 3.6
+          towncrier-version: 22.8.0  # Dropped support for Python 3.6
 
     env:
       PY_COLORS: 1

--- a/.github/workflows/tox-tests.yaml
+++ b/.github/workflows/tox-tests.yaml
@@ -53,6 +53,7 @@ jobs:
     strategy:
       matrix:
         towncrier-version:
+        - 22.8.0
         - 21.9.0rc1
         - 21.3.0
         - 19.9.0

--- a/src/sphinxcontrib/towncrier/_towncrier.py
+++ b/src/sphinxcontrib/towncrier/_towncrier.py
@@ -3,8 +3,18 @@
 from pathlib import Path
 from typing import Any, Dict
 
-# pylint: disable=import-error,no-name-in-module
-from towncrier._settings import load_config_from_file  # noqa: WPS436
+
+try:
+    # Towncrier < 22.8.0
+    # pylint: disable=import-error,no-name-in-module
+    from towncrier._settings import (  # noqa: WPS433, WPS436
+        load_config_from_file,
+    )
+except ImportError:
+    # pylint: disable=import-error,no-name-in-module
+    from towncrier._settings.load import (  # noqa: WPS433, WPS436, WPS440
+        load_config_from_file,
+    )
 
 
 def get_towncrier_config(

--- a/src/sphinxcontrib/towncrier/_towncrier.py
+++ b/src/sphinxcontrib/towncrier/_towncrier.py
@@ -5,14 +5,14 @@ from typing import Any, Dict
 
 
 try:
-    # Towncrier < 22.8.0
+    # Towncrier >= 22.8.0rc1
     # pylint: disable=import-error,no-name-in-module
-    from towncrier._settings import (  # noqa: WPS433, WPS436
+    from towncrier._settings.load import (  # noqa: WPS433, WPS436
         load_config_from_file,
     )
 except ImportError:
     # pylint: disable=import-error,no-name-in-module
-    from towncrier._settings.load import (  # noqa: WPS433, WPS436, WPS440
+    from towncrier._settings import (  # noqa: WPS433, WPS436, WPS440
         load_config_from_file,
     )
 


### PR DESCRIPTION
This patch implements compatibility with the newly released `towncrier >= 22.8.0rc1`. Since the extension relies on the Towncrier's private API, this sort of thing is bound to happen time to time. It is solved by using a fallback import logic.

This change also adds the said Towncrier version to the CI matrix.

Fixes #60.