### PR TITLE
Update build-system dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,10 @@
 [build-system]
 requires = [
   # Essentials
-  "setuptools>=40.6.0",
+  "setuptools >= 64",
 
   # Plugins
-  "setuptools_scm[toml] >= 3.5",  # version is required for "no-local-version" scheme + toml extra is needed for supporting config in this file
-  "setuptools_scm_git_archive >= 1.1",
+  "setuptools_scm[toml] >= 8",  # version is required for "no-local-version" scheme + toml extra is needed for supporting config in this file
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
pyproject.toml:
Update setuptools-scm to >= 7.1.0 to drop the requirement for setuptools-scm-git-archive (since the functionality is included since 7.0.0).
Update requirement for setuptools accordingly.