### PR TITLE
Prefer `towncrier.toml` over `pyproject.toml` if present

### DIFF
--- a/src/sphinxcontrib/towncrier/_fragment_discovery.py
+++ b/src/sphinxcontrib/towncrier/_fragment_discovery.py
@@ -1,0 +1,84 @@
+"""Changelog fragment discovery helpers."""
+
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional, Set
+
+from sphinx.util import logging
+
+
+try:
+    # pylint: disable=no-name-in-module
+    from towncrier.build import find_fragments  # noqa: WPS433
+except ImportError:
+    # pylint: disable=import-self,no-name-in-module
+    from towncrier import (  # type: ignore[attr-defined] # noqa: WPS433,WPS440
+        find_fragments,
+    )
+
+from ._towncrier import get_towncrier_config  # noqa: WPS436
+
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_spec_config(
+        base: Path, spec_name: Optional[str] = None,
+) -> Optional[Path]:
+    return base / spec_name if spec_name is not None else None
+
+
+# pylint: disable=fixme
+# FIXME: consider consolidating this logic upstream in towncrier
+def _find_config_file(base: Path) -> Path:
+    """Find the best config file."""
+    candidate_names = 'towncrier.toml', 'pyproject.toml'
+    candidates = list(map(base.joinpath, candidate_names))
+    extant = filter(Path.is_file, candidates)
+    return next(extant, candidates[-1])
+
+
+# pylint: disable=fixme
+# FIXME: refactor `lookup_towncrier_fragments` to drop noqas
+@lru_cache(maxsize=1, typed=True)  # noqa: WPS210
+def lookup_towncrier_fragments(  # noqa: WPS210
+        working_dir: Optional[str] = None,
+        config_path: Optional[str] = None,
+) -> Set[Path]:
+    """Emit RST-formatted Towncrier changelog fragment paths."""
+    project_path = Path.cwd() if working_dir is None else Path(working_dir)
+
+    final_config_path = (
+        _resolve_spec_config(project_path, config_path)
+        or _find_config_file(project_path)
+    )
+
+    try:
+        towncrier_config = get_towncrier_config(
+            project_path,
+            final_config_path,
+        )
+    except KeyError as key_err:
+        # NOTE: The error is missing key 'towncrier' or similar
+        logger.warning(
+            f'Missing key {key_err!s} in file {final_config_path!s}',
+        )
+        return set()
+
+    fragment_directory: Optional[str] = 'newsfragments'
+    try:
+        fragment_base_directory = project_path / towncrier_config['directory']
+    except KeyError:
+        assert fragment_directory is not None
+        fragment_base_directory = project_path / fragment_directory
+    else:
+        fragment_directory = None
+
+    _fragments, fragment_filenames = find_fragments(
+        str(fragment_base_directory),
+        towncrier_config['sections'],
+        fragment_directory,
+        towncrier_config['types'],
+    )
+    return set(fragment_filenames)

--- a/src/sphinxcontrib/towncrier/ext.py
+++ b/src/sphinxcontrib/towncrier/ext.py
@@ -97,7 +97,8 @@ def _get_changelog_draft_entries(
 
 
 def _resolve_spec_config(
-        base: Path, spec_name: Optional[str] = None) -> Optional[Path]:
+        base: Path, spec_name: Optional[str] = None,
+) -> Optional[Path]:
     return base / spec_name if spec_name is not None else None
 
 

--- a/src/sphinxcontrib/towncrier/ext.py
+++ b/src/sphinxcontrib/towncrier/ext.py
@@ -19,14 +19,6 @@ from sphinx.util.nodes import nested_parse_with_titles, nodes
 
 # isort: split
 
-try:
-    # pylint: disable=no-name-in-module
-    from towncrier.build import find_fragments  # noqa: WPS433
-except ImportError:
-    # pylint: disable=import-self,no-name-in-module
-    from towncrier import (  # type: ignore[attr-defined] # noqa: WPS433,WPS440
-        find_fragments,
-    )
 
 # Ref: https://github.com/PyCQA/pylint/issues/3817
 from docutils import statemachine  # pylint: disable=wrong-import-order
@@ -35,7 +27,7 @@ from ._compat import shlex_join  # noqa: WPS436
 from ._data_transformers import (  # noqa: WPS436
     escape_project_version_rst_substitution,
 )
-from ._towncrier import get_towncrier_config  # noqa: WPS436
+from ._fragment_discovery import lookup_towncrier_fragments  # noqa: WPS436
 from ._version import __version__  # noqa: WPS436
 
 
@@ -94,67 +86,6 @@ def _get_changelog_draft_entries(
         raise LookupError('There are no unreleased changelog entries so far')
 
     return towncrier_output
-
-
-def _resolve_spec_config(
-        base: Path, spec_name: Optional[str] = None,
-) -> Optional[Path]:
-    return base / spec_name if spec_name is not None else None
-
-
-# pylint: disable=fixme
-# FIXME: consider consolidating this logic upstream in towncrier
-def _find_config_file(base: Path) -> Path:
-    """Find the best config file."""
-    candidate_names = 'towncrier.toml', 'pyproject.toml'
-    candidates = list(map(base.joinpath, candidate_names))
-    extant = filter(Path.is_file, candidates)
-    return next(extant, candidates[-1])
-
-
-# pylint: disable=fixme
-# FIXME: refactor `_lookup_towncrier_fragments` to drop noqas
-@lru_cache(maxsize=1, typed=True)  # noqa: WPS210
-def _lookup_towncrier_fragments(  # noqa: WPS210
-        working_dir: Optional[str] = None,
-        config_path: Optional[str] = None,
-) -> Set[Path]:
-    """Emit RST-formatted Towncrier changelog fragment paths."""
-    project_path = Path.cwd() if working_dir is None else Path(working_dir)
-
-    final_config_path = (
-        _resolve_spec_config(project_path, config_path)
-        or _find_config_file(project_path)
-    )
-
-    try:
-        towncrier_config = get_towncrier_config(
-            project_path,
-            final_config_path,
-        )
-    except KeyError as key_err:
-        # NOTE: The error is missing key 'towncrier' or similar
-        logger.warning(
-            f'Missing key {key_err!s} in file {final_config_path!s}',
-        )
-        return set()
-
-    fragment_directory: Optional[str] = 'newsfragments'
-    try:
-        fragment_base_directory = project_path / towncrier_config['directory']
-    except KeyError:
-        assert fragment_directory is not None
-        fragment_base_directory = project_path / fragment_directory
-    else:
-        fragment_directory = None
-
-    _fragments, fragment_filenames = find_fragments(
-        str(fragment_base_directory),
-        towncrier_config['sections'],
-        fragment_directory,
-        towncrier_config['types'],
-    )
-    return set(fragment_filenames)
 
 
 @lru_cache(maxsize=1, typed=True)
@@ -222,7 +153,7 @@ class TowncrierDraftEntriesDirective(SphinxDirective):
         autoversion_mode = config.towncrier_draft_autoversion_mode
         include_empty = config.towncrier_draft_include_empty
 
-        towncrier_fragment_paths = _lookup_towncrier_fragments(
+        towncrier_fragment_paths = lookup_towncrier_fragments(
             working_dir=config.towncrier_draft_working_directory,
             config_path=config.towncrier_draft_config_path,
         )
@@ -372,7 +303,7 @@ class TowncrierDraftEntriesEnvironmentCollector(EnvironmentCollector):
 
         This is a handler for :event:`env-get-outdated`.
         """
-        towncrier_fragment_paths = _lookup_towncrier_fragments(
+        towncrier_fragment_paths = lookup_towncrier_fragments(
             working_dir=env.config.towncrier_draft_working_directory,
             config_path=env.config.towncrier_draft_config_path,
         )

--- a/src/sphinxcontrib/towncrier/ext.py
+++ b/src/sphinxcontrib/towncrier/ext.py
@@ -100,13 +100,10 @@ def _get_changelog_draft_entries(
 # FIXME: consider consolidating this logic upstream in towncrier
 def _find_config_file(base: Path, spec_name: Optional[str] = None) -> Path:
     """Find the best config file."""
-    found = base / 'pyproject.toml'
     if spec_name is not None:
-        found = base / spec_name
-    elif (  # noqa: WPS337
-            not found.is_file() and
-            (base / 'towncrier.toml').is_file()
-    ):
+        return base / spec_name
+    found = base / 'pyproject.toml'
+    if not found.is_file() and (base / 'towncrier.toml').is_file():
         found = base / 'towncrier.toml'
     return found
 

--- a/src/sphinxcontrib/towncrier/ext.py
+++ b/src/sphinxcontrib/towncrier/ext.py
@@ -102,10 +102,10 @@ def _find_config_file(base: Path, spec_name: Optional[str] = None) -> Path:
     """Find the best config file."""
     if spec_name is not None:
         return base / spec_name
-    found = base / 'pyproject.toml'
-    if not found.is_file() and (base / 'towncrier.toml').is_file():
-        found = base / 'towncrier.toml'
-    return found
+    candidate_names = 'pyproject.toml', 'towncrier.toml'
+    candidates = list(map(base.joinpath, candidate_names))
+    extant = filter(Path.is_file, candidates)
+    return next(extant, candidates[0])
 
 
 # pylint: disable=fixme

--- a/src/sphinxcontrib/towncrier/ext.py
+++ b/src/sphinxcontrib/towncrier/ext.py
@@ -97,6 +97,21 @@ def _get_changelog_draft_entries(
 
 
 # pylint: disable=fixme
+# FIXME: consider consolidating this logic upstream in towncrier
+def _find_config_file(base: Path, spec_name: Optional[str] = None) -> Path:
+    """Find the best config file."""
+    found = base / 'pyproject.toml'
+    if spec_name is not None:
+        found = base / spec_name
+    elif (  # noqa: WPS337
+            not found.is_file() and
+            (base / 'towncrier.toml').is_file()
+    ):
+        found = base / 'towncrier.toml'
+    return found
+
+
+# pylint: disable=fixme
 # FIXME: refactor `_lookup_towncrier_fragments` to drop noqas
 @lru_cache(maxsize=1, typed=True)  # noqa: WPS210
 def _lookup_towncrier_fragments(  # noqa: WPS210
@@ -106,14 +121,7 @@ def _lookup_towncrier_fragments(  # noqa: WPS210
     """Emit RST-formatted Towncrier changelog fragment paths."""
     project_path = Path.cwd() if working_dir is None else Path(working_dir)
 
-    final_config_path = project_path / 'pyproject.toml'
-    if config_path is not None:
-        final_config_path = project_path / config_path
-    elif (  # noqa: WPS337
-            not final_config_path.is_file() and
-            (project_path / 'towncrier.toml').is_file()
-    ):
-        final_config_path = project_path / 'towncrier.toml'
+    final_config_path = _find_config_file(project_path, config_path)
 
     try:
         towncrier_config = get_towncrier_config(

--- a/src/sphinxcontrib/towncrier/ext.py
+++ b/src/sphinxcontrib/towncrier/ext.py
@@ -102,10 +102,10 @@ def _find_config_file(base: Path, spec_name: Optional[str] = None) -> Path:
     """Find the best config file."""
     if spec_name is not None:
         return base / spec_name
-    candidate_names = 'pyproject.toml', 'towncrier.toml'
+    candidate_names = 'towncrier.toml', 'pyproject.toml'
     candidates = list(map(base.joinpath, candidate_names))
     extant = filter(Path.is_file, candidates)
-    return next(extant, candidates[0])
+    return next(extant, candidates[-1])
 
 
 # pylint: disable=fixme

--- a/src/sphinxcontrib/towncrier/ext.py
+++ b/src/sphinxcontrib/towncrier/ext.py
@@ -96,12 +96,15 @@ def _get_changelog_draft_entries(
     return towncrier_output
 
 
+def _resolve_spec_config(
+        base: Path, spec_name: Optional[str] = None) -> Optional[Path]:
+    return base / spec_name if spec_name is not None else None
+
+
 # pylint: disable=fixme
 # FIXME: consider consolidating this logic upstream in towncrier
-def _find_config_file(base: Path, spec_name: Optional[str] = None) -> Path:
+def _find_config_file(base: Path) -> Path:
     """Find the best config file."""
-    if spec_name is not None:
-        return base / spec_name
     candidate_names = 'towncrier.toml', 'pyproject.toml'
     candidates = list(map(base.joinpath, candidate_names))
     extant = filter(Path.is_file, candidates)
@@ -118,7 +121,10 @@ def _lookup_towncrier_fragments(  # noqa: WPS210
     """Emit RST-formatted Towncrier changelog fragment paths."""
     project_path = Path.cwd() if working_dir is None else Path(working_dir)
 
-    final_config_path = _find_config_file(project_path, config_path)
+    final_config_path = (
+        _resolve_spec_config(project_path, config_path)
+        or _find_config_file(project_path)
+    )
 
     try:
         towncrier_config = get_towncrier_config(

--- a/tests/_fragment_discovery_test.py
+++ b/tests/_fragment_discovery_test.py
@@ -1,0 +1,47 @@
+"""Unit tests of the fragment discovery logic."""
+import pytest
+
+from sphinxcontrib.towncrier._fragment_discovery import _find_config_file
+
+
+PYPROJECT_TOML_FILENAME = 'pyproject.toml'
+TOWNCRIER_TOML_FILENAME = 'towncrier.toml'
+
+
+@pytest.mark.parametrize(
+    ('config_file_names_on_disk', 'expected_config_file_name'),
+    (
+        pytest.param(
+            set(),
+            PYPROJECT_TOML_FILENAME,
+            id='pyproject.toml-when-no-configs',
+        ),
+        pytest.param(
+            {PYPROJECT_TOML_FILENAME},
+            'pyproject.toml',
+            id='pyproject.toml-only',
+        ),
+        pytest.param(
+            {TOWNCRIER_TOML_FILENAME},
+            TOWNCRIER_TOML_FILENAME,
+            id='towncrier.toml-only',
+        ),
+        pytest.param(
+            {PYPROJECT_TOML_FILENAME, TOWNCRIER_TOML_FILENAME},
+            TOWNCRIER_TOML_FILENAME,
+            id='towncrier.toml-over-pyproject.toml',
+        ),
+    ),
+)
+def test_find_config_file(
+        config_file_names_on_disk,
+        expected_config_file_name,
+        tmp_path,
+) -> None:
+    """Verify that the correct Towncrier config is always preferred."""
+    for config_file_name_on_disk in config_file_names_on_disk:
+        tmp_path.joinpath(config_file_name_on_disk).write_text(
+            '', encoding='utf-8',
+        )
+
+    assert _find_config_file(tmp_path).name == expected_config_file_name

--- a/tests/units_test.py
+++ b/tests/units_test.py
@@ -10,6 +10,8 @@ from sphinxcontrib.towncrier.ext import (
 
 
 NO_OUTPUT_MARKER = r'\[No output\]'
+PYPROJECT_TOML_FILENAME = 'pyproject.toml'
+TOWNCRIER_TOML_FILENAME = 'towncrier.toml'
 
 
 _get_changelog_draft_entries_unwrapped = (
@@ -104,17 +106,23 @@ def test_towncrier_draft_generation_failure_msg(
     ('config_file_names_on_disk', 'expected_config_file_name'),
     (
         pytest.param(
-            set(), 'pyproject.toml', id='pyproject.toml-when-no-configs',
+            set(),
+            PYPROJECT_TOML_FILENAME,
+            id='pyproject.toml-when-no-configs',
         ),
         pytest.param(
-            {'pyproject.toml'}, 'pyproject.toml', id='pyproject.toml-only',
+            {PYPROJECT_TOML_FILENAME},
+            'pyproject.toml',
+            id='pyproject.toml-only',
         ),
         pytest.param(
-            {'towncrier.toml'}, 'towncrier.toml', id='towncrier.toml-only',
+            {TOWNCRIER_TOML_FILENAME},
+            TOWNCRIER_TOML_FILENAME,
+            id='towncrier.toml-only',
         ),
         pytest.param(
-            {'pyproject.toml', 'towncrier.toml'},
-            'towncrier.toml',
+            {PYPROJECT_TOML_FILENAME, TOWNCRIER_TOML_FILENAME},
+            TOWNCRIER_TOML_FILENAME,
             id='towncrier.toml-over-pyproject.toml',
         ),
     ),

--- a/tests/units_test.py
+++ b/tests/units_test.py
@@ -100,15 +100,34 @@ def test_towncrier_draft_generation_failure_msg(
         _get_changelog_draft_entries_unwrapped(version_string)
 
 
-def test_find_config_files_empty(tmp_path):
-    assert _find_config_file(tmp_path).name == 'pyproject.toml'
+@pytest.mark.parametrize(
+    ('config_file_names_on_disk', 'expected_config_file_name'),
+    (
+        pytest.param(
+            set(), 'pyproject.toml', id='pyproject.toml-when-no-configs',
+        ),
+        pytest.param(
+            {'pyproject.toml'}, 'pyproject.toml', id='pyproject.toml-only',
+        ),
+        pytest.param(
+            {'towncrier.toml'}, 'towncrier.toml', id='towncrier.toml-only',
+        ),
+        pytest.param(
+            {'pyproject.toml', 'towncrier.toml'},
+            'towncrier.toml',
+            id='towncrier.toml-over-pyproject.toml',
+        ),
+    ),
+)
+def test_find_config_files(
+        config_file_names_on_disk,
+        expected_config_file_name,
+        tmp_path,
+) -> None:
+    """Verify that the correct Towncrier config is always preferred."""
+    for config_file_name_on_disk in config_file_names_on_disk:
+        tmp_path.joinpath(config_file_name_on_disk).write_text(
+            '', encoding='utf-8',
+        )
 
-
-def test_find_config_files_pyproject(tmp_path):
-    tmp_path.joinpath('pyproject.toml').write_text('', encoding='utf-8')
-    assert _find_config_file(tmp_path).name == 'pyproject.toml'
-
-
-def test_find_config_files_towncrier(tmp_path):
-    tmp_path.joinpath('towncrier.toml').write_text('', encoding='utf-8')
-    assert _find_config_file(tmp_path).name == 'towncrier.toml'
+    assert _find_config_file(tmp_path).name == expected_config_file_name

--- a/tests/units_test.py
+++ b/tests/units_test.py
@@ -4,7 +4,9 @@ import sys
 import pytest
 
 from sphinxcontrib.towncrier._compat import shlex_join
-from sphinxcontrib.towncrier.ext import _get_changelog_draft_entries, _find_config_file
+from sphinxcontrib.towncrier.ext import (
+    _find_config_file, _get_changelog_draft_entries,
+)
 
 
 NO_OUTPUT_MARKER = r'\[No output\]'

--- a/tests/units_test.py
+++ b/tests/units_test.py
@@ -4,7 +4,7 @@ import sys
 import pytest
 
 from sphinxcontrib.towncrier._compat import shlex_join
-from sphinxcontrib.towncrier.ext import _get_changelog_draft_entries
+from sphinxcontrib.towncrier.ext import _get_changelog_draft_entries, _find_config_file
 
 
 NO_OUTPUT_MARKER = r'\[No output\]'
@@ -96,3 +96,17 @@ def test_towncrier_draft_generation_failure_msg(
 
     with pytest.raises(RuntimeError, match=expected_error_message):
         _get_changelog_draft_entries_unwrapped(version_string)
+
+
+def test_find_config_files_empty(tmp_path):
+    assert _find_config_file(tmp_path).name == 'pyproject.toml'
+
+
+def test_find_config_files_pyproject(tmp_path):
+    tmp_path.joinpath('pyproject.toml').write_text('', encoding='utf-8')
+    assert _find_config_file(tmp_path).name == 'pyproject.toml'
+
+
+def test_find_config_files_towncrier(tmp_path):
+    tmp_path.joinpath('towncrier.toml').write_text('', encoding='utf-8')
+    assert _find_config_file(tmp_path).name == 'towncrier.toml'

--- a/tests/units_test.py
+++ b/tests/units_test.py
@@ -4,14 +4,10 @@ import sys
 import pytest
 
 from sphinxcontrib.towncrier._compat import shlex_join
-from sphinxcontrib.towncrier.ext import (
-    _find_config_file, _get_changelog_draft_entries,
-)
+from sphinxcontrib.towncrier.ext import _get_changelog_draft_entries
 
 
 NO_OUTPUT_MARKER = r'\[No output\]'
-PYPROJECT_TOML_FILENAME = 'pyproject.toml'
-TOWNCRIER_TOML_FILENAME = 'towncrier.toml'
 
 
 _get_changelog_draft_entries_unwrapped = (
@@ -100,42 +96,3 @@ def test_towncrier_draft_generation_failure_msg(
 
     with pytest.raises(RuntimeError, match=expected_error_message):
         _get_changelog_draft_entries_unwrapped(version_string)
-
-
-@pytest.mark.parametrize(
-    ('config_file_names_on_disk', 'expected_config_file_name'),
-    (
-        pytest.param(
-            set(),
-            PYPROJECT_TOML_FILENAME,
-            id='pyproject.toml-when-no-configs',
-        ),
-        pytest.param(
-            {PYPROJECT_TOML_FILENAME},
-            'pyproject.toml',
-            id='pyproject.toml-only',
-        ),
-        pytest.param(
-            {TOWNCRIER_TOML_FILENAME},
-            TOWNCRIER_TOML_FILENAME,
-            id='towncrier.toml-only',
-        ),
-        pytest.param(
-            {PYPROJECT_TOML_FILENAME, TOWNCRIER_TOML_FILENAME},
-            TOWNCRIER_TOML_FILENAME,
-            id='towncrier.toml-over-pyproject.toml',
-        ),
-    ),
-)
-def test_find_config_files(
-        config_file_names_on_disk,
-        expected_config_file_name,
-        tmp_path,
-) -> None:
-    """Verify that the correct Towncrier config is always preferred."""
-    for config_file_name_on_disk in config_file_names_on_disk:
-        tmp_path.joinpath(config_file_name_on_disk).write_text(
-            '', encoding='utf-8',
-        )
-
-    assert _find_config_file(tmp_path).name == expected_config_file_name


### PR DESCRIPTION
Fixes #81 

- Extract helper function for finding the config file.
- Refactor _find_config_file for simplicity.
- Refactor to generalize the search across a list of two candidates.
- Re-order search path for config files to match towncrier.
