### PR TITLE
Make the project compatible with Towncrier >= 24.7

### DIFF
--- a/src/sphinxcontrib/towncrier/_fragment_discovery.py
+++ b/src/sphinxcontrib/towncrier/_fragment_discovery.py
@@ -67,11 +67,24 @@ def lookup_towncrier_fragments(  # noqa: WPS210
     else:
         fragment_directory = None
 
-    # pylint: disable-next=too-many-function-args
-    _fragments, fragment_filenames = find_fragments(
-        str(fragment_base_directory),
-        towncrier_config.sections,
-        fragment_directory,
-        towncrier_config.types,
-    )
+    try:
+        # Towncrier < 24.7.0rc1
+        # pylint: disable-next=no-value-for-parameter,unexpected-keyword-arg
+        _fragments, fragment_filenames = find_fragments(
+            base_directory=str(fragment_base_directory),
+            sections=towncrier_config.sections,
+            fragment_directory=fragment_directory,
+            frag_type_names=towncrier_config.types,
+            orphan_prefix='+',
+        )
+    except TypeError:
+        # Towncrier >= 24.7.0rc1
+        _fragments, fragment_filenames = find_fragments(  # noqa: WPS121
+            base_directory=str(fragment_base_directory),
+            config=towncrier_config,
+            strict=False,
+        )
+
+        return {Path(fname[0]) for fname in fragment_filenames}
+
     return set(fragment_filenames)


### PR DESCRIPTION
@webknjaz  this is a first pass at solving this problem, feel free to suggest alternative approaches to tackling the issue. Ultimately it is very simple to solve for only new Towncrier, but maintaining backwards compatibility is more difficult. In the end I opted to basically have side by side implementations of the key `lookup_towncrier_fragments()` function. This means that there is a little bit more duplicated code between the two versions than there needs to be, but it also means that when/if support for pre 24.7 Towncrier is dropped it will be easy to just delete the older function. I can change this if you prefer a single function.

I also renamed `get_towncrier_config()` to `get_towncrier_config_as_dict()` to make way for a new version of `get_towncrier_config()` returning the new dataclass `Config` object. This breaks backwards compatibility and I could have implemented a new `get_towncrier_config_as_dataclass()` function instead, but given the very small chance that any other dependent code is using that function I thought it was nicer to keep the main function name providing the current API. Again, happy to change if you prefer the other way.

These changes solve #92 on my system (Windows, Py3.12) but there are no existing tests of this functionality and I haven't yet added any. If you approve of the general implementation of the fix then I can add some tests to go along with it (any suggestions about how you would like those to look would also be welcome).

original commit msg below:
towncrier 24.7 changed the way that its find_fragments() function works to accept a Config dataclass instead of specific components of the config. This commit adds a new version of lookup_towncrier_fragments() to use the new API and chooses which one to use based on the version of towncrier obtained from importlib.metadata. It also slightly changes the way that towncrier config can be obtained: the previous get_towncrier_config() function (which returned a dict) is now renamed as get_towncrier_config_as_dict() and get_towncrier_config() returns the new Config dataclass object for towncrier versions above 22.12.0rc1 and raises NotImplementedError for older versions. This API change should be ok as get_towncrier_config() was only called in one place before.