### PR TITLE
🧪💅 Move caching pre-commit venvs to a hook

### DIFF
--- a/.github/stdlib-workflows/reusable-tox/actions/post-src-checkout/action.yml
+++ b/.github/stdlib-workflows/reusable-tox/actions/post-src-checkout/action.yml
@@ -1,0 +1,29 @@
+---
+
+inputs:
+  calling-job-context:
+    description: A JSON with the calling job inputs
+    type: string
+
+runs:
+  using: composite
+  steps:
+  - name: Log setting up pre-commit cache
+    if: fromJSON(inputs.calling-job-context).toxenv == 'pre-commit'
+    run: >-
+      >&2 echo Caching ~/.cache/pre-commit based on
+      the contents of `.pre-commit-config.yaml`...
+    shell: bash
+  - name: Cache pre-commit.com virtualenvs
+    if: fromJSON(inputs.calling-job-context).toxenv == 'pre-commit'
+    uses: actions/cache@v4
+    with:
+      path: ~/.cache/pre-commit
+      key: >-
+        ${{
+          runner.os
+        }}-pre-commit-${{
+          hashFiles('.pre-commit-config.yaml')
+        }}
+
+...

--- a/.github/workflows/reusable-tox.yml
+++ b/.github/workflows/reusable-tox.yml
@@ -209,17 +209,14 @@ jobs:
         source-tarball-name: ${{ inputs.source-tarball-name }}
         workflow-artifact-name: ${{ inputs.dists-artifact-name }}
 
-    - name: Cache pre-commit.com virtualenvs
-      if: inputs.toxenv == 'pre-commit'
-      uses: actions/cache@v4
+    - name: 🪝 Invoke the in-repo `post-src-checkout` hook (if exists)
+      if: >-  # `hashFiles()` is used as a rudimentary `file.exists()`
+        hashFiles(
+          '.github/stdlib-workflows/reusable-tox/actions/post-src-checkout/action.yml'
+        ) != ''
+      uses: ./.github/stdlib-workflows/reusable-tox/actions/post-src-checkout
       with:
-        path: ~/.cache/pre-commit
-        key: >-
-          ${{
-            runner.os
-          }}-pre-commit-${{
-            hashFiles('.pre-commit-config.yaml')
-          }}
+        calling-job-context: ${{ toJSON(inputs) }}
 
     - name: Set up pip cache
       uses: re-actors/cache-python-deps@release/v1


### PR DESCRIPTION
This patch introduces a concept of hooks to reusable workflows, starting with post-src-checkout.